### PR TITLE
Implement `MultiplyWithCarry` in `UInt128` arithmetic

### DIFF
--- a/src/BitSift.jl
+++ b/src/BitSift.jl
@@ -15,6 +15,7 @@ export XorMatrix
 export xor_mul
 export add_mod
 export mul_mod
+export mul_mod2  # TODO
 
 abstract type AbstractBitHash end
 

--- a/src/hashes.jl
+++ b/src/hashes.jl
@@ -37,13 +37,13 @@ struct MultiplyWithCarry <: AbstractBitHash
 end
 
 function query(rng::MultiplyWithCarry, key::UInt64)::UInt64
-    m::BigInt = (BigInt(rng.reduced_multiplier) << 64) - 1
-    a::BigInt = invmod(BigInt(1) << 64, m)
-    x::BigInt = (BigInt(rng.seed_c) << 64) | rng.seed_x
+    m::UInt128 = (UInt128(rng.reduced_multiplier) << 64) - 1
+    a::UInt128 = invmod(UInt128(1) << 64, m)
+    x::UInt128 = (UInt128(rng.seed_c) << 64) | rng.seed_x
     for i in 0:63
-        x = (key >> i) & 1 == 1 ? (a * x) % m : x
+        x = (key >> i) & 1 == 1 ? mul_mod(a, x, m) : x
         # Two steps: a * ((a * x) % m) = ((a * a) % m) * x
-        a = (a * a) % m
+        a = mul_mod(a, a, m)
     end
     return x & typemax(UInt64)
 end

--- a/src/hashes.jl
+++ b/src/hashes.jl
@@ -41,9 +41,9 @@ function query(rng::MultiplyWithCarry, key::UInt64)::UInt64
     a::UInt128 = invmod(UInt128(1) << 64, m)
     x::UInt128 = (UInt128(rng.seed_c) << 64) | rng.seed_x
     for i in 0:63
-        x = (key >> i) & 1 == 1 ? mul_mod(a, x, m) : x
+        x = (key >> i) & 1 == 1 ? mul_mod2(a, x, m) : x
         # Two steps: a * ((a * x) % m) = ((a * a) % m) * x
-        a = mul_mod(a, a, m)
+        a = mul_mod2(a, a, m)
     end
     return x & typemax(UInt64)
 end

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -74,6 +74,7 @@ end
     b::UInt128 = 0xff057b7ef767814f14057b7ef767814f % m
     @test add_mod(a, b, m) == _add_mod_ref(a, b, m)
     @test mul_mod(a, b, m) == _mul_mod_ref(a, b, m)
+    @test mul_mod2(a, b, m) == _mul_mod_ref(a, b, m)
 
     rng = SplitMix()
     for k in 1:100
@@ -83,5 +84,6 @@ end
         b = (UInt128(query(rng, UInt64(i + 4))) << 64 | query(rng, UInt64(i + 5))) % m
         @test add_mod(a, b, m) == _add_mod_ref(a, b, m)
         @test mul_mod(a, b, m) == _mul_mod_ref(a, b, m)
+        @test mul_mod2(a, b, m) == _mul_mod_ref(a, b, m)
     end
 end


### PR DESCRIPTION
The current implementation uses `BigInt` to implement 128-bit multiply-into-modulo. This shows up as sluggishness and allocations in the benchmark.

Result: **failure**. BigInt is very good. I would love to avoid the allocations, though. There are much better big-int algorithms, but I need to research them.

---

### BigInt backend

[`main cbe5567e8682513927c48d451dc65deeb0e01d3f`](https://github.com/Rupt/BitSift.jl/commit/cbe5567e8682513927c48d451dc65deeb0e01d3f)

```text
julia -- bench/mwc.jl
  13.393 μs (594 allocations: 10.81 KiB)
```

### `mul_mod` built from `add_mod`:

[`rt/non-big-int-mwc 5f206c3558f9f0e0a20d1eeae293f36fdb9cae4e`](https://github.com/Rupt/BitSift.jl/commit/5f206c3558f9f0e0a20d1eeae293f36fdb9cae4e)


```text
julia -- bench/mwc.jl
  89.404 μs (1 allocation: 16 bytes)
```

### `mul_mod` built from 128-bit algebra

[`rt/non-big-int-mwc e2132b3c6304b5155aee20531daa4026ee1e1d14`](https://github.com/Rupt/BitSift.jl/commit/e2132b3c6304b5155aee20531daa4026ee1e1d14)

```text
julia -- bench/mwc.jl
  395.984 μs (1 allocation: 16 bytes)
```
